### PR TITLE
Fix B-1 bug in generate_mol

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,113 +81,110 @@ options shown below, or by using a configuration file. These options can be view
  
     Running Lignin-KMC version 0.2.2. Please cite: https://pubs.acs.org/doi/abs/10.1021/acssuschemeng.9b03534
      
-    usage: _jb_unittest_runner.py [-h] [-a ADD_RATES] [-c CONFIG] [-d OUT_DIR]
-                                  [-dy] [-e] [-f OUTPUT_FORMAT_LIST]
+    usage: _jb_unittest_runner.py [-h] [-a ADD_RATES] [-b] [-c CONFIG]
+                                  [-d OUT_DIR] [-dy] [-f OUTPUT_FORMAT_LIST]
                                   [-i INITIAL_NUM_MONOMERS] [-l LENGTH_SIMULATION]
                                   [-m MAX_NUM_MONOMERS] [-n NUM_REPEATS]
                                   [-o OUTPUT_BASENAME] [-p] [-r RANDOM_SEED]
                                   [-s IMAGE_SIZE] [-sg SG_RATIOS]
-                                  [-t TEMPERATURE_IN_K] [--chain_id CHAIN_ID]
+                                  [-t TEMPERATURE_IN_K] [-x] [--chain_id CHAIN_ID]
                                   [--psf_fname PSF_FNAME]
                                   [--toppar_dir TOPPAR_DIR]
-     
+    
     Create lignin chain(s) composed of 'S' (syringyl) and/or 'G' (guaiacol) monolignols, as described in:
-       Orella, M., Gani, T. Z. H., Vermaas, J. V., Stone, M. L., Anderson, E. M., Beckham, G. T., 
-       Brushett, Fikile R., Roman-Leshkov, Y. (2019). Lignin-KMC: A Toolkit for Simulating Lignin Biosynthesis.
-       ACS Sustainable Chemistry & Engineering. https://doi.org/10.1021/acssuschemeng.9b03534. C-Lignin can be 
-       modeled with the functions in this package, as shown in ipynb examples in our project package on github 
-       (https://github.com/michaelorella/lignin-kmc/), but not currently from the command line. If this 
-       functionality is desired, please start a new issue on the github.
-     
-       By default, the Gibbs free energy barriers from this reference will be used, as specified in Tables S1 and S2.
-       Alternately, the user may specify values, which should be specified as a dict of dict of dicts in a 
-       specified configuration file (specified with '-c') using the 'e_barrier_in_kcal_mol' or 'e_barrier_in_j_particle'
-       parameters with corresponding units (kcal/mol or joules/particle, respectively), in a configuration file 
-       (see '-c'). The format is (bond_type: monomer(s) involved: units involved: delta_g_298), for example:
-           barriers_kcalmol = {oxidation: {'G': {monomer: 0.9, oligomer: 6.3}, 'S': {{{MONOMER}: 0.6, {OLIGOMER}: 2.2}}, ...}.
-       The default output is a SMILES string printed to standard out.
-     
-       All command-line options may alternatively be specified in a configuration file. Command-line (non-default) 
-       selections will override configuration file specifications.
-     
+      Orella, M., Gani, T. Z. H., Vermaas, J. V., Stone, M. L., Anderson, E. M., Beckham, G. T., 
+      Brushett, Fikile R., Roman-Leshkov, Y. (2019). Lignin-KMC: A Toolkit for Simulating Lignin Biosynthesis.
+      ACS Sustainable Chemistry & Engineering. https://doi.org/10.1021/acssuschemeng.9b03534. C-Lignin can be 
+      modeled with the functions in this package, as shown in ipynb examples in our project package on github 
+      (https://github.com/michaelorella/lignin-kmc/), but not currently from the command line. If this 
+      functionality is desired, please start a new issue on the github.
+    
+      By default, the Gibbs free energy barriers from this reference will be used, as specified in Tables S1 and S2.
+      Alternately, the user may specify values, which should be specified as a dict of dict of dicts in a 
+      specified configuration file (specified with '-c') using the 'e_barrier_in_kcal_mol' or 'e_barrier_in_j_particle'
+      parameters with corresponding units (kcal/mol or joules/particle, respectively), in a configuration file 
+      (see '-c'). The format is (bond_type: monomer(s) involved: units involved: ea_vals), for example:
+          ea_dict = {oxidation: {'G': {monomer: 0.9, oligomer: 6.3}, 'S': {{{MONOMER}: 0.6, {OLIGOMER}: 2.2}}, ...}.
+      The default output is a SMILES string printed to standard out.
+    
+      All command-line options may alternatively be specified in a configuration file. Command-line (non-default) 
+      selections will override configuration file specifications.
+    
     optional arguments:
-       -h, --help            show this help message and exit
-       -a ADD_RATES, --add_rates ADD_RATES
-                             A comma-separated list of the rates of monomer addition to the system (in monomers/second), 
-                             to be used when the 'max_num_monomers' ('-m' option) is larger than 'initial_num_monomers' 
-                             ('-i' option), thus specifying monomer addition. The simulation will end when either there 
-                             are no more possible reactions (including monomer addition) or when the 'length_simulation' 
-                             ('-l' option) is reached, whichever comes first. Note: if there are spaces in the list of 
-                             addition rates, the list must be enclosed in quotes to be read as a single string. The 
-                             default list contains the single addition rate of 1.0 monomers/s.
-       -c CONFIG, --config CONFIG
-                             The location of the configuration file in the 'ini' format. This file can be used to 
-                             overwrite default values such as for energies.
-       -d OUT_DIR, --out_dir OUT_DIR
-                             The directory where output files will be saved. The default is the current directory.
-       -dy, --dynamics_flag  Select this option if dynamics (results per timestep) are requested. If chosen, plots of 
-                             monomers and oligomers vs timestep, and bond type percent vs timestep, will be saved. 
-                             They will be named 'bond_dist_v_step_*_#.png' and 'mono_olig_v_step_*_#.png', where * 
-                             represents the S:G ratio and # represents the addition rate. Note that this option 
-                             significantly increases simulation time.
-       -e, --energy_barriers_flag
-                             By default, the reaction rates will be based on the energy barriers in kcal/mol to be used 
-                             to calculate reaction rates at 298.15 K. If this flag is used, the rates use to produce the 
-                             original manuscript plots will be used (missing one term). Alternate sets of energy 
-                             barriers can be specified; see the main help message.
-       -f OUTPUT_FORMAT_LIST, --output_format_list OUTPUT_FORMAT_LIST
-                             The type(s) of output format to be saved. Provide as a space- or comma-separated list. 
-                             Note: if the list has spaces, it must be enclosed in quotes, to be treated as a single 
-                             string. The currently supported types are: 'json', 'png', 'smi', 'svg', 'tcl'. 
-                             The 'json' option will save a json format of RDKit's 'mol' (molecule) object. The 'tcl' 
-                             option will create a file for use with VMD to generate a psf file and 3D molecules, 
-                             as described in LigninBuilder, https://github.com/jvermaas/LigninBuilder, 
-                             https://pubs.acs.org/doi/abs/10.1021/acssuschemeng.8b05665. 
-                             A base name for the saved files can be provided with the '-o' option. Otherwise, the 
-                             base name will be 'lignin-kmc-out'.
-       -i INITIAL_NUM_MONOMERS, --initial_num_monomers INITIAL_NUM_MONOMERS
-                             The initial number of monomers to be included in the simulation. The default is 2.
-       -l LENGTH_SIMULATION, --length_simulation LENGTH_SIMULATION
-                             The length of simulation (simulation time) in seconds. The default is 3600 s.
-       -m MAX_NUM_MONOMERS, --max_num_monomers MAX_NUM_MONOMERS
-                             The maximum number of monomers to be studied. The default value is 10.
-       -n NUM_REPEATS, --num_repeats NUM_REPEATS
-                             The number of times each combination of sg_ratio and add_rate will be tested. 
-                             The default is 1.
-       -o OUTPUT_BASENAME, --output_basename OUTPUT_BASENAME
-                             The base name for output file(s). If an extension is provided, it will determine 
-                             the type of output. Currently supported output types are: 
-                             'json', 'png', 'smi', 'svg', 'tcl'. Multiple output formats can be selected with the 
-                             '-f' option. If the '-f' option is selected and no output base name provided, a default 
-                             base name of 'lignin-kmc-out' will be used.
-       -p, --plot_bonds      Flag to produce plots of the percent of each bond type versus S:G ratio(s). One plot will 
-                             be created per addition rate, named 'bond_dist_v_sg_#.png', where # represents 
-                             the addition rate.
-       -r RANDOM_SEED, --random_seed RANDOM_SEED
-                             A positive integer to be used as a seed value for testing. The default is not to use a 
-                             seed, to allow pseudorandom lignin creation.
-       -s IMAGE_SIZE, --image_size IMAGE_SIZE
-                             The output size of svg or png files in pixels. The default size is (1200, 300) pixels. 
-                             To use a different size, provide two integers, separated by a space or a comma. 
-                             Note: if the list of two numbers has any spaces in it, it must be enclosed in quotes.
-       -sg SG_RATIOS, --sg_ratios SG_RATIOS
-                             A comma-separated list of the S:G (guaiacol:syringyl) ratios to be tested. 
-                             If there are spaces, the list must be enclosed in quotes to be read as a single string. 
-                             The default list contains the single value 1.
-       -t TEMPERATURE_IN_K, --temperature_in_k TEMPERATURE_IN_K
-                             The temperature (in K) at which to model lignin biosynthesis. The default is 298.15 K.
-                             Note: this temperature must match the temperature at which the energy barriers were calculated. 
-       --chain_id CHAIN_ID   Option for use when generating a tcl script: the chainID to be used in generating a psf 
-                             and/or pdb file from a tcl script (see LigninBuilder). This should be one character. If a 
-                             longer ID is provided, it will be truncated to the first character. The default value is L.
-       --psf_fname PSF_FNAME
-                             Option for use when generating a tcl script: the file name for psf and pdb files that will 
-                             be produced from running a tcl produced by this package (see LigninBuilder). The default 
-                             value is lignin.
-       --toppar_dir TOPPAR_DIR
-                             Option for use when generating a tcl script: the directory name where VMD should look for 
-                             the toppar file(s) when running the tcl file in VMD (see LigninBuilder). The default value 
-                             is 'toppar/'.
+      -h, --help            show this help message and exit
+      -a ADD_RATES, --add_rates ADD_RATES
+                            A comma-separated list of the rates of monomer addition to the system (in monomers/second), 
+                            to be used when the 'max_num_monomers' ('-m' option) is larger than 'initial_num_monomers' 
+                            ('-i' option), thus specifying monomer addition. The simulation will end when either there 
+                            are no more possible reactions (including monomer addition) or when the 'length_simulation' 
+                            ('-l' option) is reached, whichever comes first. Note: if there are spaces in the list of 
+                            addition rates, the list must be enclosed in quotes to be read as a single string. The 
+                            default list contains the single addition rate of 1.0 monomers/s.
+      -b, --break_co_bonds  Flag to output results from C-O bonds to simulate RCF results. The default is False.
+      -c CONFIG, --config CONFIG
+                            The location of the configuration file in the 'ini' format. This file can be used to 
+                            overwrite default values such as for energies.
+      -d OUT_DIR, --out_dir OUT_DIR
+                            The directory where output files will be saved. The default is the current directory.
+      -dy, --dynamics_flag  Select this option if dynamics (results per timestep) are requested. If chosen, plots of 
+                            monomers and oligomers vs timestep, and bond type percent vs timestep, will be saved. 
+                            They will be named 'bond_dist_v_step_*_#.png' and 'mono_olig_v_step_*_#.png', where * 
+                            represents the S:G ratio and # represents the addition rate. Note that this option 
+                            significantly increases simulation time.
+      -f OUTPUT_FORMAT_LIST, --output_format_list OUTPUT_FORMAT_LIST
+                            The type(s) of output format to be saved. Provide as a space- or comma-separated list. 
+                            Note: if the list has spaces, it must be enclosed in quotes, to be treated as a single 
+                            string. The currently supported types are: 'json', 'png', 'smi', 'svg', 'tcl'. 
+                            The 'json' option will save a json format of RDKit's 'mol' (molecule) object. The 'tcl' 
+                            option will create a file for use with VMD to generate a psf file and 3D molecules, 
+                            as described in LigninBuilder, https://github.com/jvermaas/LigninBuilder, 
+                            https://pubs.acs.org/doi/abs/10.1021/acssuschemeng.8b05665. 
+                            A base name for the saved files can be provided with the '-o' option. Otherwise, the 
+                            base name will be 'lignin-kmc-out'.
+      -i INITIAL_NUM_MONOMERS, --initial_num_monomers INITIAL_NUM_MONOMERS
+                            The initial number of monomers to be included in the simulation. The default is 2.
+      -l LENGTH_SIMULATION, --length_simulation LENGTH_SIMULATION
+                            The length of simulation (simulation time) in seconds. The default is 3600 s.
+      -m MAX_NUM_MONOMERS, --max_num_monomers MAX_NUM_MONOMERS
+                            The maximum number of monomers to be studied. The default value is 10.
+      -n NUM_REPEATS, --num_repeats NUM_REPEATS
+                            The number of times each combination of sg_ratio and add_rate will be tested. The default is 1.
+      -o OUTPUT_BASENAME, --output_basename OUTPUT_BASENAME
+                            The base name for output file(s). If an extension is provided, it will determine 
+                            the type of output. Currently supported output types are: 
+                            'json', 'png', 'smi', 'svg', 'tcl'. Multiple output formats can be selected with the 
+                            '-f' option. If the '-f' option is selected and no output base name provided, a default 
+                            base name of 'lignin-kmc-out' will be used.
+      -p, --plot_bonds      Flag to produce plots of the percent of each bond type versus S:G ratio(s). One plot will 
+                            be created per addition rate, named 'bond_dist_v_sg_#.png', where # represents 
+                            the addition rate.
+      -r RANDOM_SEED, --random_seed RANDOM_SEED
+                            A positive integer to be used as a seed value for testing. The default is not to use a 
+                            seed, to allow pseudorandom lignin creation.
+      -s IMAGE_SIZE, --image_size IMAGE_SIZE
+                            The output size of svg or png files in pixels. The default size is (1200, 300) pixels. 
+                            To use a different size, provide two integers, separated by a space or a comma. 
+                            Note: if the list of two numbers has any spaces in it, it must be enclosed in quotes.
+      -sg SG_RATIOS, --sg_ratios SG_RATIOS
+                            A comma-separated list of the S:G (guaiacol:syringyl) ratios to be tested. 
+                            If there are spaces, the list must be enclosed in quotes to be read as a single string. 
+                            The default list contains the single value 1.
+      -t TEMPERATURE_IN_K, --temperature_in_k TEMPERATURE_IN_K
+                            The temperature (in K) at which to model lignin biosynthesis. The default is 298.15 K.
+                            Note: this temperature must match the temperature at which the energy barriers were calculated. 
+      -x, --no_smi          Flag to suppress determining the SMILES string for the output, which is created by default.
+      --chain_id CHAIN_ID   Option for use when generating a tcl script: the chainID to be used in generating a psf 
+                            and/or pdb file from a tcl script (see LigninBuilder). This should be one character. If a 
+                            longer ID is provided, it will be truncated to the first character. The default value is L.
+      --psf_fname PSF_FNAME
+                            Option for use when generating a tcl script: the file name for psf and pdb files that will 
+                            be produced from running a tcl produced by this package (see LigninBuilder). The default 
+                            value is lignin.
+      --toppar_dir TOPPAR_DIR
+                            Option for use when generating a tcl script: the directory name where VMD should look for 
+                            the toppar file(s) when running the tcl file in VMD (see LigninBuilder). The default value 
+                            is 'toppar/'.
+
 
 For example, to use an S to G ratio of 2.5, 12 initial monomers, and up to 18 monomers, with the remaining variables 
 left as their default values, enter:

--- a/ligninkmc/create_lignin.py
+++ b/ligninkmc/create_lignin.py
@@ -93,7 +93,7 @@ OPENING_MSG = f"Running Lignin-KMC version {__version__}. " \
 
 def plot_bond_error_bars(x_axis, y_axis_val_dicts, y_axis_std_dev_dicts, y_val_key_list, x_axis_label, y_axis_label,
                          plot_title, plot_fname):
-    plt.figure(figsize=(3.5, 3.5))
+    plt.figure(figsize=(3, 5))
     for y_idx, y_key in enumerate(y_val_key_list):
         plt.errorbar(x_axis, y_axis_val_dicts[y_key], yerr=y_axis_std_dev_dicts[y_key], linestyle='none', marker='.',
                      markersize=10, markerfacecolor=PLOT_COLORS[y_idx], markeredgecolor=PLOT_COLORS[y_idx],

--- a/ligninkmc/create_lignin.py
+++ b/ligninkmc/create_lignin.py
@@ -8,8 +8,6 @@ Multiple output options, from tcl files to plots
 import argparse
 import os
 import sys
-from _ctypes import ArgumentError
-
 import numpy as np
 import matplotlib.pyplot as plt
 from collections import (defaultdict)
@@ -588,9 +586,6 @@ def create_initial_monomers(pct_s, monomer_draw):
                          "S", otherwise
     :return: list of Monomer objects of specified type
     """
-    # TODO: If want more than 2 monomer options, need to change logic; that will require an overhaul, since
-    #       sg_ratio is often used. However, until we have Gibbs free energy barriers for bonding between more than
-    #       just S and G, no need to update
     # if mon_choice < pct_s, make it an S; that is, the evaluation comes back True (=1='S');
     #     otherwise, get False = 0 = 'G'. Since only two options (True/False) only works for 2 monomers
     return [Monomer(INT_TO_TYPE_DICT[int(mono_type_draw < pct_s)], i) for i, mono_type_draw in enumerate(monomer_draw)]

--- a/ligninkmc/kmc_common.py
+++ b/ligninkmc/kmc_common.py
@@ -499,7 +499,6 @@ class Monomer:
         elif unit_type == S:
             self.open = {4, 8}
         else:
-            # todo: update once H is added
             raise InvalidDataError(f"Encountered unit type {unit_type},  but only the following types are "
                                    f"currently available: 'G' ({G}), 'S' ({S}), 'C' ({C})")
         self.connectedTo = {i}

--- a/ligninkmc/kmc_functions.py
+++ b/ligninkmc/kmc_functions.py
@@ -459,18 +459,12 @@ def update_state_for_bimolecular_rxn(bonding_partners, cleaned_partners, cur_n, 
         size = (quick_frag_size(mon), quick_frag_size(partner))
         if bond[0] in mon.open and bond[1] in partner.open:
             try:
-                # todo: delete when questions re olig-olig b04 bond is resolved
-                if size == (OLIGOMER, OLIGOMER) and rxn_event[0] == BO4 and \
-                        mon.type == S and partner.type == S:
-                    raise InvalidDataError(f"{rxn_event[0]} reaction between oligomers with "
-                                           f"{mon.identity} and {partner.identity}")
                 # "/ cur_n**2" is like multiplying by concentration of each of 2 monomers,
                 #     ignoring any molecules not tracked by this script
                 rate = rxn_event[2][(mon.type, partner.type)][size] / (cur_n ** 2)
             except KeyError:
-                raise InvalidDataError(f"Error while attempting to update event_dict: event "
-                                       f"{rxn_event[0]} between indices {mon.identity} and "
-                                       f"{partner.identity} ")
+                raise InvalidDataError(f"Error while attempting to update event_dict: event {rxn_event[0]} between "
+                                       f"indices {mon.identity} and {partner.identity} ")
 
             # Add this to both the monomer and it's bonding partners list of event_dict that need to be
             #     modified upon manipulation of either monomer

--- a/ligninkmc/kmc_functions.py
+++ b/ligninkmc/kmc_functions.py
@@ -810,8 +810,8 @@ def generate_mol(adj, node_list):
 
     for pair in paired_adj:
         # Find the types of bonds and indices associated with each of the elements in the adjacency matrix
-        # Indices are extracted as tuples (row,col) and we just want the row for each
-        mono_indices = [x[0] for x in pair]
+        # Indices are extracted as tuples (row,col) and we just want the row for each        
+        mono_indices, _ = pair
 
         # Get the monomers corresponding to the indices in this bond
         mons = [None, None]
@@ -902,9 +902,6 @@ def generate_mol(adj, node_list):
         #     1) Disconnect the original 1 -> A bond that existed from the not beta monomer
         #     2) Convert the new primary alcohol to an aldehyde
         if sorted(bond_loc) == [1, 8]:
-            # TODO: make sure all B1 bonds are correctly forms
-            warning("There are problems in how this program currently builds molecules with B1 bonds. Carefully "
-                    "check any output.")
             index_for_one = int(not beta[tuple(bond_loc)])
             # Convert the alpha alcohol on one's tail to an aldehyde
             alpha_idx = mono_start_idx_atom[mono_indices[index_for_one]
@@ -912,7 +909,11 @@ def generate_mol(adj, node_list):
 
             # Temporarily join the bonds so that we can find the string
             temp = ''.join(bonds)
-            matches = re.findall(f'M {2}V30 [0-9]+ 1 {alpha_idx} [0-9]+', temp)
+
+            # Here was bug, as {2} wasn't escaped properly before we were looking
+            # for the string 'M 2V30...' which could never be found and resulted
+            # in the value error - see PEP498
+            matches = re.findall(rf'M {{2}}V30 [0-9]+ 1 {alpha_idx} [0-9]+', temp)
 
             # Find the bond connecting the alpha to the alcohol
             others = []
@@ -920,8 +921,6 @@ def generate_mol(adj, node_list):
                 bound_atoms = re.split(' +', possibility)[4:]
                 others.extend([int(x) for x in bound_atoms if int(x) != alpha_idx])
 
-            # TODO: Fix the section below--it does not work; for now, simply catch the error and provide a
-            #   descriptive failure message (instead of a stack trace)
             # The oxygen atom should have the greatest index of the atoms bound to the alpha position because it
             #     was added last
             try:
@@ -935,7 +934,9 @@ def generate_mol(adj, node_list):
                 del (bonds[alpha_ring_bond_index])
                 removed[BONDS] += 1
             except ValueError:
-                return None
+                raise ValueError(f'Couldn\'t find the bond connecting α-carbon '
+                                 f'to the alcohol. We think α-carbon={alpha_idx}, '
+                                 f'but can\'t identify the oxygen index.')
 
     mol_bond_blocks = ''.join(bonds)
     mol_atom_blocks = ''.join(atoms)

--- a/ligninkmc/kmc_functions.py
+++ b/ligninkmc/kmc_functions.py
@@ -750,7 +750,7 @@ def generate_mol(adj, node_list):
                       7: {x: 6 for x in [G, S, C]}, 8: {x: 7 for x in [G, S, C]}, 10: {x: 9 for x in [G, S, C]}}
     alpha_beta_alkene_location = 7
     alpha_ring_location = 6
-    alpha = 7
+    alpha_carbon_index = 7
 
     for i, mon in enumerate(node_list):
         # Build the individual monomers before they are linked by anything
@@ -810,8 +810,8 @@ def generate_mol(adj, node_list):
 
     for pair in paired_adj:
         # Find the types of bonds and indices associated with each of the elements in the adjacency matrix
-        # Indices are extracted as tuples (row,col) and we just want the row for each        
-        mono_indices, _ = pair
+        # Indices are extracted as tuples (row,col) and we just want the row for each, as list for consistent order
+        mono_indices = [x[0] for x in pair]
 
         # Get the monomers corresponding to the indices in this bond
         mons = [None, None]
@@ -905,14 +905,10 @@ def generate_mol(adj, node_list):
             index_for_one = int(not beta[tuple(bond_loc)])
             # Convert the alpha alcohol on one's tail to an aldehyde
             alpha_idx = mono_start_idx_atom[mono_indices[index_for_one]
-                                            ] + site_positions[alpha][mons[index_for_one].type]
+                                            ] + site_positions[alpha_carbon_index][mons[index_for_one].type]
 
             # Temporarily join the bonds so that we can find the string
             temp = ''.join(bonds)
-
-            # Here was bug, as {2} wasn't escaped properly before we were looking
-            # for the string 'M 2V30...' which could never be found and resulted
-            # in the value error - see PEP498
             matches = re.findall(rf'M {{2}}V30 [0-9]+ 1 {alpha_idx} [0-9]+', temp)
 
             # Find the bond connecting the alpha to the alcohol
@@ -934,9 +930,8 @@ def generate_mol(adj, node_list):
                 del (bonds[alpha_ring_bond_index])
                 removed[BONDS] += 1
             except ValueError:
-                raise ValueError(f'Couldn\'t find the bond connecting α-carbon '
-                                 f'to the alcohol. We think α-carbon={alpha_idx}, '
-                                 f'but can\'t identify the oxygen index.')
+                raise ValueError(f'Could mot find the bond connecting α-carbon (atom index {alpha_idx}) to the alcohol '
+                                 f'(could not identify the oxygen atom index).')
 
     mol_bond_blocks = ''.join(bonds)
     mol_atom_blocks = ''.join(atoms)

--- a/ligninkmc/kmc_functions.py
+++ b/ligninkmc/kmc_functions.py
@@ -903,8 +903,7 @@ def generate_mol(adj, node_list):
         #     2) Convert the new primary alcohol to an aldehyde
         if sorted(bond_loc) == [1, 8]:
             # TODO: make sure all B1 bonds are correctly forms
-            warning("There are problems in how this program currently builds molecules with B1 bonds. Carefully "
-                    "check any output.")
+            warning("There are problems in how this program currently builds molecules with B1 bonds.")
             index_for_one = int(not beta[tuple(bond_loc)])
             # Convert the alpha alcohol on one's tail to an aldehyde
             alpha_idx = mono_start_idx_atom[mono_indices[index_for_one]

--- a/tests/test_create_lignin.py
+++ b/tests/test_create_lignin.py
@@ -293,7 +293,7 @@ class TestCreateLigninNormalUse(unittest.TestCase):
             self.assertFalse(diff_lines(TEST_SMI_OUT_TEMP_DIR, GOOD_TEST_SMI_OUT))
         finally:
             silent_remove(TEST_SMI_OUT_TEMP_DIR, disable=DISABLE_REMOVE)
-            silent_remove(TEMP_DIR, disable=DISABLE_REMOVE)
+            silent_remove(TEMP_DIR, dir_with_files=True, disable=DISABLE_REMOVE)
             silent_remove(INNER_TEMP_DIR, disable=DISABLE_REMOVE)
             pass
 
@@ -521,23 +521,39 @@ class TestDynamics(unittest.TestCase):
             silent_remove(TEMP_DIR, dir_with_files=True, disable=DISABLE_REMOVE)
             pass
 
-    def testTryOvercomeB1Error(self):
-        random_number = 1
-        test_input = ["-i", "5", "-m", "200", "-a", "1", "-e",
-                      "-sg", "1, 3, 5, 10", "-n", "3", "-r", str(random_number)]
+    def testCheckForValenceError(self):
+        # todo: fix valence error
+        random_seed = 1
+        test_input = ["-i", "5", "-m", "200", "-a", "1",
+                      "-sg", "1, 3, 5, 10", "-n", "3", "-r", str(random_seed)]
+        # main(test_input)
         with capture_stderr(main, test_input) as output:
-            self.assertTrue("Will repeat step" in output)
-            self.assertTrue("error in producing output" in output)
+            if output:
+                print("Encountered error:\n", output)
+            self.assertFalse(output)
 
-    # Do not include the following in test coverage--just an easy way to run this for its production output
+    def testCheckSBonding(self):
+        random_seed = 10
+        test_input = ["-i", "2", "-m", "64", "-a", "1e2",
+                      "-sg", "10000000", "-r", str(random_seed)]
+        # main(test_input)
+        with capture_stderr(main, test_input) as output:
+            self.assertFalse("Exiting program due to error in producing output" in output)
+
+    # Added as an easy way to run this for its production output
     def testProduction(self):
         # new_out_dir = os.path.join(DATA_DIR, 'new_plots')
         # more efficient to just look at "1e8, 1e6, 1e4" and "1,  3, 5, 10"
         # for a full list: "-a",  "1e8, 1e6, 1e4, 1e2, 1"
         #                  "-sg", "0.1, 0.2, 0.25, 0.33, 0.5, 1, 2, 3, 4, 5, 10",
         #                  "-n", "5"m "-d", new_out_dir
-        plot_input = ["-i", "5", "-m", "200", "-a", "1", "-x",
-                      "-sg", "1, 3, 5, 10", "-n", "3", "-p", "-d", TEMP_DIR]
+        plot_input = ["-x", "-p",
+                      # next line: testing
+                      "-i", "5", "-m", "100", "-a", "1", "-sg", "1, 10", "-n", "3", "-d", TEMP_DIR,
+                      # # alt lines: production
+                      # "-i", "2", "-m", "500", "-l", "1e5", "-a", "1e8, 1e6, 1e4, 1e2, 1",
+                      # "-sg", "0.1, 0.2, 0.25, 0.33, 0.5, 1, 2, 3, 4, 5, 10", "-n", "100", "-d", new_out_dir,
+                      ]
         try:
             with capture_stderr(main, plot_input) as output:
                 self.assertFalse(output)

--- a/tests/test_create_lignin.py
+++ b/tests/test_create_lignin.py
@@ -293,7 +293,7 @@ class TestCreateLigninNormalUse(unittest.TestCase):
             self.assertFalse(diff_lines(TEST_SMI_OUT_TEMP_DIR, GOOD_TEST_SMI_OUT))
         finally:
             silent_remove(TEST_SMI_OUT_TEMP_DIR, disable=DISABLE_REMOVE)
-            silent_remove(TEMP_DIR, disable=DISABLE_REMOVE)
+            silent_remove(TEMP_DIR, dir_with_files=True, disable=DISABLE_REMOVE)
             silent_remove(INNER_TEMP_DIR, disable=DISABLE_REMOVE)
             pass
 
@@ -522,22 +522,37 @@ class TestDynamics(unittest.TestCase):
             pass
 
     def testTryOvercomeB1Error(self):
-        random_number = 1
+        random_seed = 1
         test_input = ["-i", "5", "-m", "200", "-a", "1", "-e",
-                      "-sg", "1, 3, 5, 10", "-n", "3", "-r", str(random_number)]
+                      "-sg", "1, 3, 5, 10", "-n", "3", "-r", str(random_seed)]
         with capture_stderr(main, test_input) as output:
             self.assertTrue("Will repeat step" in output)
             self.assertTrue("error in producing output" in output)
 
-    # Do not include the following in test coverage--just an easy way to run this for its production output
+    def testCheckSBonding(self):
+        # todo: update after B1 error fixed
+        random_seed = 10
+        test_input = ["-i", "2", "-m", "64", "-a", "1e2",
+                      # "-e",
+                      "-sg", "10000000", "-r", str(random_seed)]
+        # main(test_input)
+        with capture_stderr(main, test_input) as output:
+            self.assertTrue("Exiting program due to error in producing output", output)
+
+    # Added as an easy way to run this for its production output
     def testProduction(self):
         # new_out_dir = os.path.join(DATA_DIR, 'new_plots')
         # more efficient to just look at "1e8, 1e6, 1e4" and "1,  3, 5, 10"
         # for a full list: "-a",  "1e8, 1e6, 1e4, 1e2, 1"
         #                  "-sg", "0.1, 0.2, 0.25, 0.33, 0.5, 1, 2, 3, 4, 5, 10",
         #                  "-n", "5"m "-d", new_out_dir
-        plot_input = ["-i", "5", "-m", "200", "-a", "1", "-x",
-                      "-sg", "1, 3, 5, 10", "-n", "3", "-p", "-d", TEMP_DIR]
+        plot_input = ["-x", "-p",
+                      # next line: testing
+                      "-i", "5", "-m", "200", "-a", "1", "-sg", "1, 3, 5, 10", "-n", "3", "-d", TEMP_DIR,
+                      # # alt lines: production
+                      # "-i", "2", "-m", "500", "-l", "1e5", "-a", "1e8, 1e6, 1e4, 1e2, 1",
+                      # "-sg", "0.1, 0.2, 0.25, 0.33, 0.5, 1, 2, 3, 4, 5, 10", "-n", "100", "-d", new_out_dir,
+                      ]
         try:
             with capture_stderr(main, plot_input) as output:
                 self.assertFalse(output)

--- a/tests/test_create_lignin.py
+++ b/tests/test_create_lignin.py
@@ -522,10 +522,8 @@ class TestDynamics(unittest.TestCase):
             pass
 
     def testCheckForValenceError(self):
-        # todo: fix valence error
         random_seed = 1
-        test_input = ["-i", "5", "-m", "200", "-a", "1",
-                      "-sg", "1, 3, 5, 10", "-n", "3", "-r", str(random_seed)]
+        test_input = ["-i", "5", "-m", "200", "-a", "1", "-sg", "1, 3, 5, 10", "-n", "3", "-r", str(random_seed)]
         # main(test_input)
         with capture_stderr(main, test_input) as output:
             if output:
@@ -534,8 +532,7 @@ class TestDynamics(unittest.TestCase):
 
     def testCheckSBonding(self):
         random_seed = 10
-        test_input = ["-i", "2", "-m", "64", "-a", "1e2",
-                      "-sg", "10000000", "-r", str(random_seed)]
+        test_input = ["-i", "2", "-m", "64", "-a", "1e2", "-sg", "10000000", "-r", str(random_seed)]
         # main(test_input)
         with capture_stderr(main, test_input) as output:
             self.assertFalse("Exiting program due to error in producing output" in output)
@@ -543,10 +540,6 @@ class TestDynamics(unittest.TestCase):
     # Added as an easy way to run this for its production output
     def testProduction(self):
         # new_out_dir = os.path.join(DATA_DIR, 'new_plots')
-        # more efficient to just look at "1e8, 1e6, 1e4" and "1,  3, 5, 10"
-        # for a full list: "-a",  "1e8, 1e6, 1e4, 1e2, 1"
-        #                  "-sg", "0.1, 0.2, 0.25, 0.33, 0.5, 1, 2, 3, 4, 5, 10",
-        #                  "-n", "5"m "-d", new_out_dir
         plot_input = ["-x", "-p",
                       # next line: testing
                       "-i", "5", "-m", "100", "-a", "1", "-sg", "1, 10", "-n", "3", "-d", TEMP_DIR,

--- a/tests/test_lignin_kmc_parts.py
+++ b/tests/test_lignin_kmc_parts.py
@@ -623,10 +623,9 @@ class TestVisualization(unittest.TestCase):
             pass
 
     def testB1BondGenMol(self):
-        # TODO: Update test when the B1 bond problem is resolved.
         ini_mono_type_list = [S, S, S, G, S]
         sg_ratio = 1.0
-        max_monos = 500
+        max_monos = 12
         random_num = 55
         initial_monomers = [Monomer(mono_type, i) for i, mono_type in enumerate(ini_mono_type_list)]
         initial_events = create_initial_events(initial_monomers, DEF_RXN_RATES)
@@ -636,7 +635,7 @@ class TestVisualization(unittest.TestCase):
                          random_seed=random_num, sg_ratio=sg_ratio)
         nodes = result[MONO_LIST]
         adj = result[ADJ_MATRIX]
-
+        # generate_mol(adj, nodes)
         with capture_stderr(generate_mol, adj, nodes) as output:
             self.assertFalse(output)
 
@@ -688,10 +687,6 @@ class TestVisualization(unittest.TestCase):
             self.assertEqual(len(val_list), expected_num_t_steps)
             olig_len_sum_dict[olig_len] = sum(val_list)
         self.assertEqual(olig_len_sum_dict, good_olig_len_sum_dict)
-
-        # sum_sums = int(sum(sum_list))
-        # good_sum_sum_list = 312
-        # self.assertEqual(sum_sums, good_sum_sum_list)
 
     def testIniRates(self):
         # Note: this test did not increase coverage. Added to help debug notebook.

--- a/tests/test_lignin_kmc_parts.py
+++ b/tests/test_lignin_kmc_parts.py
@@ -636,6 +636,7 @@ class TestVisualization(unittest.TestCase):
                          random_seed=random_num, sg_ratio=sg_ratio)
         nodes = result[MONO_LIST]
         adj = result[ADJ_MATRIX]
+        # generate_mol(adj, nodes)
         with capture_stderr(generate_mol, adj, nodes) as output:
             self.assertTrue("B1 bonds" in output)
 
@@ -676,10 +677,6 @@ class TestVisualization(unittest.TestCase):
             self.assertEqual(len(val_list), expected_num_t_steps)
             olig_len_sum_dict[olig_len] = sum(val_list)
         self.assertEqual(olig_len_sum_dict, good_olig_len_sum_dict)
-
-        # sum_sums = int(sum(sum_list))
-        # good_sum_sum_list = 312
-        # self.assertEqual(sum_sums, good_sum_sum_list)
 
     def testIniRates(self):
         # Note: this test did not increase coverage. Added to help debug notebook.


### PR DESCRIPTION
There was an error before with how the B-1
bonds were being converted into molefiles, which
was causing a ValueError to be raised during
execution if a B-1 bond had been formed during
the simulation. This should update the code to
ensure that does not occur anymore.

Addresses #8  