### PR TITLE
Fix the logic in the psf writing script

### DIFF
--- a/ligninkmc/kmc_functions.py
+++ b/ligninkmc/kmc_functions.py
@@ -1034,7 +1034,7 @@ def gen_tcl(orig_adj, monomers, tcl_fname=DEF_TCL_FNAME, psf_fname=DEF_PSF_FNAME
         else:
             chain_id = DEF_CHAIN_ID
         warning(f"ChainID's for PDBs should be one character. Will use: '{chain_id}' as the chainID.")
-    residue_letter = {G: 'G', S: 'S', H: 'H', C: 'C'}
+    residue_name = {G: 'GUAI', S: 'SYR', H: 'PHP', C: 'CAT'}
     f_out = create_out_fname(tcl_fname, base_dir=out_dir)
     # add a mac/linux dir separator if there isn't already a directory separator, and if there is to be a subdirectory
     #   (not None or "")
@@ -1050,7 +1050,7 @@ def gen_tcl(orig_adj, monomers, tcl_fname=DEF_TCL_FNAME, psf_fname=DEF_PSF_FNAME
                 f"segment {chain_id} {{\n")
         for monomer in monomers:
             resid = monomer.identity + 1
-            res_name = residue_letter[monomer.type]
+            res_name = residue_name[monomer.type]
             f.write(f"    residue {resid} {res_name}\n")
         f.write(f"}}\n")
 
@@ -1086,9 +1086,9 @@ def gen_tcl(orig_adj, monomers, tcl_fname=DEF_TCL_FNAME, psf_fname=DEF_PSF_FNAME
             elif bond_loc1 == 4 and bond_loc2 == 7:  # Reverse alpha-O-4 linkage
                 write_patch(f, "AO4", chain_id, psf_patch_resid2, psf_patch_resid1)
             elif bond_loc1 == 4 and bond_loc2 == 5:  # 4O5 linkage
-                write_patch(f, "4O4", chain_id, psf_patch_resid1, psf_patch_resid2)
+                write_patch(f, "4O5", chain_id, psf_patch_resid1, psf_patch_resid2)
             elif bond_loc1 == 5 and bond_loc2 == 4:  # Reverse 4O5 linkage
-                write_patch(f, "4O4", chain_id, psf_patch_resid2, psf_patch_resid1)
+                write_patch(f, "4O5", chain_id, psf_patch_resid2, psf_patch_resid1)
             elif bond_loc1 == 8 and bond_loc2 == 1:  # Beta-1 linkage
                 write_patch(f, "B1", chain_id, psf_patch_resid1, psf_patch_resid2)
             elif bond_loc1 == 1 and bond_loc2 == 8:  # Reverse beta-1 linkage


### PR DESCRIPTION
The logic for gen_tcl was missing a few things. In CHARMM, the residue names are GUAI, SYR, PHP, and CAT, and psfgen wouldn't find the correct residues if the names were written out. The patches I made also expect there to be a 405, not a 404 patch.